### PR TITLE
update to recent changes for go-backlog and go-github

### DIFF
--- a/backlog/backlog.go
+++ b/backlog/backlog.go
@@ -68,7 +68,7 @@ func NewService(config *Config) (*Service, error) {
 	}
 	name := u.Host
 
-	c := backlog.NewClient(config.BaseURL, config.APIKey)
+	c := backlog.NewClient(u, config.APIKey)
 	user, err := c.Myself()
 	if err != nil {
 		return nil, err

--- a/github/github.go
+++ b/github/github.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -108,12 +109,13 @@ func (p *Issue) Number() int {
 }
 
 func (p *Issue) fetchComments(page int) ([]*github.IssueComment, int, error) {
+	ctx := context.Background()
 	owner := p.repositoryOwner()
 	repo := p.repositoryName()
 	n := p.Number()
 	var opt github.IssueListCommentsOptions
 	opt.Page = page
-	b, resp, err := p.svc.c.Issues.ListComments(owner, repo, n, &opt)
+	b, resp, err := p.svc.c.Issues.ListComments(ctx, owner, repo, n, &opt)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -166,8 +168,9 @@ func (p *Service) Name() string {
 func (p *Service) List() ([]fs.Task, error) {
 	var a []fs.Task
 	var opt github.IssueListOptions
+	ctx := context.Background()
 	for {
-		b, resp, err := p.c.Issues.List(true, &opt)
+		b, resp, err := p.c.Issues.List(ctx, true, &opt)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change fixes the following errors:
```
$ go get github.com/lufia/taskfs
# github.com/lufia/taskfs/backlog
.golang/src/github.com/lufia/taskfs/backlog/backlog.go:71:31: cannot use config.BaseURL (type string) as type *url.URL in argument to gobacklog.NewClient
# github.com/lufia/taskfs/github
.golang/src/github.com/lufia/taskfs/github/github.go:116:45: not enough arguments in call to p.svc.c.Issues.ListComments
	have (string, string, int, *github.IssueListCommentsOptions)
	want (context.Context, string, string, int, *github.IssueListCommentsOptions)
.golang/src/github.com/lufia/taskfs/github/github.go:170:34: not enough arguments in call to p.c.Issues.List
	have (bool, *github.IssueListOptions)
	want (context.Context, bool, *github.IssueListOptions)
```

Thanks.